### PR TITLE
Order by title ascending and decending now functional

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Config options
     'order:start_date_asc' = Return an ordered list by 'start_date' ASC
     'order:display_date_desc' = Return an ordered list by 'display_date' DESC
     'order:display_date_asc' = Return an ordered list by 'display_date' ASC
+    'order:title_desc' = Return an ordered list by 'title' DESC
+    'order:title_asc' = Return an ordered list by 'title' ASC
     'page_id:#' = Return only promotions in the list marked for this page
 
     'order:start_date_desc|first' = Options can be run in combination by piping to another config

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -148,6 +148,12 @@ class ParsePromos implements ParserInterface
             case 'display_date_asc':
                 usort($array, 'self::sortDisplayDateAsc');
                 break;
+            case 'title_desc':
+                usort($array, 'self::sortTitleDesc');
+                break;
+            case 'title_asc':
+                usort($array, 'self::sortTitleAsc');
+                break;
         }
 
         return $array;
@@ -203,5 +209,31 @@ class ParsePromos implements ParserInterface
             return 0;
         }
         return ($first['start_date'] < $second['start_date']) ? -1 : 1;
+    }
+
+    /**
+     * @param mixed $first
+     * @param mixed $second
+     * @return int
+     */
+    private static function sortTitleAsc($first, $second)
+    {
+        if ($first['title'] == $second['title']) {
+            return 0;
+        }
+        return ($first['title'] < $second['title']) ? -1 : 1;
+    }
+
+    /**
+     * @param mixed $first
+     * @param mixed $second
+     * @return int
+     */
+    private static function sortTitleDesc($first, $second)
+    {
+        if ($first['title'] == $second['title']) {
+            return 0;
+        }
+        return ($first['title'] > $second['title']) ? -1 : 1;
     }
 }

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -43,6 +43,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                     'page_id' => '1,2,3,4',
                     'display_start_date' => '2014-01-01',
                     'start_date' => '2014-01-01',
+                    'title' => 'Zebra',
                     'data' => 'foo',
                 ),
                 '2' => array(
@@ -51,6 +52,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                     'page_id' => '2,3,4',
                     'display_start_date' => '2014-01-02',
                     'start_date' => '2014-01-03',
+                    'title' => 'Bear',
                     'data' => 'foo',
                 ),
                 '3' => array(
@@ -59,6 +61,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                     'page_id' => '3,4',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
+                    'title' => 'Cat',
                     'data' => 'foo',
                 ),
                 '4' => array(
@@ -67,6 +70,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                     'page_id' => '4,5,6',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
+                    'title' => 'Dog',
                     'data' => 'foo',
                 ),
                 '5' => array(
@@ -75,6 +79,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                     'page_id' => '4,6,7',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
+                    'title' => 'Kitty',
                     'data' => 'foo',
                 ),
             )
@@ -290,6 +295,48 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         for ($i = 0; $i < $length - 1; ++$i) {
             // Compare the current start_date to the next item
             $this->assertLessThanOrEqual(strtotime($parsed['one'][$i+1]['start_date']), strtotime($parsed['one'][$i]['start_date']));
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldOrderByTitleAsc()
+    {
+        // Group 'one' should only return the first item
+        $config = array(
+            'one' => 'order:title_asc',
+        );
+
+        // Parse the promotions based on the config
+        $parsed = $this->parser->parse($this->promos, $this->groups, $config);
+
+        // Loop through each item - 1
+        $length = count($parsed['one']);
+        for ($i = 0; $i < $length - 1; ++$i) {
+            // Compare the current start_date to the next item
+            $this->assertGreaterThan(0, strcmp($parsed['one'][$i+1]['title'], $parsed['one'][$i]['title']));
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldOrderByTitleDesc()
+    {
+        // Group 'one' should only return the first item
+        $config = array(
+            'one' => 'order:title_desc',
+        );
+
+        // Parse the promotions based on the config
+        $parsed = $this->parser->parse($this->promos, $this->groups, $config);
+
+        // Loop through each item - 1
+        $length = count($parsed['one']);
+        for ($i = 0; $i < $length - 1; ++$i) {
+            // Compare the current start_date to the next item
+            $this->assertLessThan(0, strcmp($parsed['one'][$i+1]['title'], $parsed['one'][$i]['title']));
         }
     }
 


### PR DESCRIPTION
Added functionality:

```
'order:title_desc' = Return an ordered list by 'title' DESC
'order:title_asc' = Return an ordered list by 'title' ASC
```

Fixes #2 