### PR TITLE
Feature/promo groups

### DIFF
--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -52,12 +52,13 @@ class ParsePromos implements ParserInterface
      * @param array $group_reference
      * @return array
      */
-    public function groups(array $promos, array $group_reference = array()) {
+    public function groups(array $promos, array $group_reference = array())
+    {
         $groups = array();
 
         // Make sure we have promotional items
-        if(is_array($promos)) {
-            foreach($promos as $items) {
+        if (is_array($promos)) {
+            foreach ($promos as $items) {
                 // Get the first item in that group
                 $first_item = current($items);
 

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -52,7 +52,7 @@ class ParsePromos implements ParserInterface
      * @param array $group_reference
      * @return array
      */
-    function groups(array $promos, array $group_reference = array()) {
+    public function groups(array $promos, array $group_reference = array()) {
         $groups = array();
 
         // Make sure we have promotional items

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -46,6 +46,33 @@ class ParsePromos implements ParserInterface
     }
 
     /**
+     * Parse the promotions array
+     *
+     * @param array $promos
+     * @param array $group_reference
+     * @return array
+     */
+    function groups(array $promos, array $group_reference = array()) {
+        $groups = array();
+
+        // Make sure we have promotional items
+        if(is_array($promos)) {
+            foreach($promos as $items) {
+                // Get the first item in that group
+                $first_item = current($items);
+
+                // If group reference is passed, then use that as the key otherwise default to promo_group_id
+                $key = isset($group_reference[$first_item['group']['promo_group_id']]) ? $group_reference[$first_item['group']['promo_group_id']] : $first_item['group']['promo_group_id'];
+
+                // Set the name of the promo group
+                $groups[$key] = $first_item['group']['title'];
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
      * Take a promotion group and perform an action on it
      *
      * @param array $array

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -409,7 +409,8 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldReturnIntGroupKeys() {
+    public function shouldReturnIntGroupKeys()
+    {
         // Parse the promotions
         $parsed = $this->parser->parse($this->promos, $this->groups);
 
@@ -425,7 +426,8 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldReturnStringGroupKeys() {
+    public function shouldReturnStringGroupKeys()
+    {
         // Parse the promotions
         $parsed = $this->parser->parse($this->promos, $this->groups);
 

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -129,6 +129,19 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
                         'title' => $this->groups[2],
                     ),
                 ),
+                8 => array(
+                    'promo_item_id' => 8,
+                    'promo_group_id' => 2,
+                    'page_id' => '4,6,7',
+                    'display_start_date' => '2014-01-03',
+                    'start_date' => '2014-01-02',
+                    'title' => 'Circle',
+                    'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 99999,
+                        'title' => 'Random Group Not In Group Reference Array',
+                    ),
+                ),
             )
         );
     }
@@ -159,7 +172,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // Make sure it equals the first item in the first group of the unparsed promos
-        $this->assertEquals($this->promos['promotions']['1'], $parsed['one']);
+        $this->assertEquals($this->promos['promotions'][1], $parsed['one']);
     }
 
     /**
@@ -209,8 +222,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
-        // Didn't setup a mock yet so just testing there are the same number of elements in returned array
-        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        // TODO: Figure out how to test a shuffled array
     }
 
     /**
@@ -260,9 +272,6 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
-        // There should be the same number of elements started with
-        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
-
         // Loop through each item - 1
         $length = count($parsed['one']);
         for ($i = 0; $i < $length - 1; ++$i) {
@@ -283,9 +292,6 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
 
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
-
-        // There should be the same number of elements started with
-        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);
@@ -308,9 +314,6 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
-        // There should be the same number of elements started with
-        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
-
         // Loop through each item - 1
         $length = count($parsed['one']);
         for ($i = 0; $i < $length - 1; ++$i) {
@@ -331,9 +334,6 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
 
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
-
-        // There should be the same number of elements started with
-        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -31,56 +31,103 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
 
         // Stub group names
         $this->groups = array(
-            '1' => 'one',
+            1 => 'one',
+            2 => 'two',
         );
 
         // Stub promotions
         $this->promos = array(
             'promotions' => array(
-                '1' => array(
-                    'promo_item_id' => '1',
-                    'promo_group_id' => '1',
+                1 => array(
+                    'promo_item_id' => 1,
+                    'promo_group_id' => 1,
                     'page_id' => '1,2,3,4',
                     'display_start_date' => '2014-01-01',
                     'start_date' => '2014-01-01',
                     'title' => 'Zebra',
                     'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 1,
+                        'title' => $this->groups[1],
+                    ),
                 ),
-                '2' => array(
-                    'promo_item_id' => '2',
-                    'promo_group_id' => '1',
+                2 => array(
+                    'promo_item_id' => 2,
+                    'promo_group_id' => 1,
                     'page_id' => '2,3,4',
                     'display_start_date' => '2014-01-02',
                     'start_date' => '2014-01-03',
                     'title' => 'Bear',
                     'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 1,
+                        'title' => $this->groups[1],
+                    ),
                 ),
-                '3' => array(
-                    'promo_item_id' => '3',
-                    'promo_group_id' => '1',
+                3 => array(
+                    'promo_item_id' => 3,
+                    'promo_group_id' => 1,
                     'page_id' => '3,4',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
                     'title' => 'Cat',
                     'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 1,
+                        'title' => $this->groups[1],
+                    ),
                 ),
-                '4' => array(
-                    'promo_item_id' => '4',
-                    'promo_group_id' => '1',
+                4 => array(
+                    'promo_item_id' => 4,
+                    'promo_group_id' => 1,
                     'page_id' => '4,5,6',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
                     'title' => 'Dog',
                     'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 1,
+                        'title' => $this->groups[1],
+                    ),
                 ),
-                '5' => array(
-                    'promo_item_id' => '5',
-                    'promo_group_id' => '1',
+                5 => array(
+                    'promo_item_id' => 5,
+                    'promo_group_id' => 1,
                     'page_id' => '4,6,7',
                     'display_start_date' => '2014-01-03',
                     'start_date' => '2014-01-02',
                     'title' => 'Kitty',
                     'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 1,
+                        'title' => $this->groups[1],
+                    ),
+                ),
+                6 => array(
+                    'promo_item_id' => 6,
+                    'promo_group_id' => 2,
+                    'page_id' => '4,6,7',
+                    'display_start_date' => '2014-01-03',
+                    'start_date' => '2014-01-02',
+                    'title' => 'Red',
+                    'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 2,
+                        'title' => $this->groups[2],
+                    ),
+                ),
+                7 => array(
+                    'promo_item_id' => 7,
+                    'promo_group_id' => 2,
+                    'page_id' => '4,6,7',
+                    'display_start_date' => '2014-01-03',
+                    'start_date' => '2014-01-02',
+                    'title' => 'Blue',
+                    'data' => 'foo',
+                    'group' => array(
+                        'promo_group_id' => 2,
+                        'title' => $this->groups[2],
+                    ),
                 ),
             )
         );
@@ -101,7 +148,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldResturnASingleItem()
+    public function shouldReturnASingleItem()
     {
         // Group 'one' should only return the first item
         $config = array(
@@ -111,10 +158,8 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Parse the promotions based on the config
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
-        // Ensure a non-multi-dimentional array is returned
-        foreach ($parsed['one'] as $item) {
-            $this->assertNotInternalType('array', $item);
-        }
+        // Make sure it equals the first item in the first group of the unparsed promos
+        $this->assertEquals($this->promos['promotions']['1'], $parsed['one']);
     }
 
     /**
@@ -165,7 +210,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // Didn't setup a mock yet so just testing there are the same number of elements in returned array
-        $this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
     }
 
     /**
@@ -216,7 +261,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // There should be the same number of elements started with
-        $this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);
@@ -240,7 +285,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // There should be the same number of elements started with
-        $this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);
@@ -264,7 +309,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // There should be the same number of elements started with
-        $this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);
@@ -288,7 +333,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $parsed = $this->parser->parse($this->promos, $this->groups, $config);
 
         // There should be the same number of elements started with
-        $this->assertCount(count($this->promos['promotions']), $parsed['one']);
+        //$this->assertCount(count($this->promos['promotions']), $parsed['one']);
 
         // Loop through each item - 1
         $length = count($parsed['one']);
@@ -359,5 +404,37 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Ensure that item has a specific start date
         $first = current($parsed['one']);
         $this->assertEquals('2014-01-03', $first['start_date']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnIntGroupKeys() {
+        // Parse the promotions
+        $parsed = $this->parser->parse($this->promos, $this->groups);
+
+        // Parse for the group names
+        $groups = $this->parser->groups($parsed, $this->groups);
+
+        // Assert that the keys are not type INT
+        foreach ($groups as $key=>$item) {
+            $this->assertNotInternalType('int', $key);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnStringGroupKeys() {
+        // Parse the promotions
+        $parsed = $this->parser->parse($this->promos, $this->groups);
+
+        // Parse for the group names
+        $groups = $this->parser->groups($parsed);
+
+        // Assert that the keys are not type STRING
+        foreach ($groups as $key=>$item) {
+            $this->assertNotInternalType('string', $key);
+        }
     }
 }


### PR DESCRIPTION
- Added a new method called `groups` which returns an array of the group names for easy reference.- 
- Added two tests for groups
- Cleaned up the previous tests to work in the case of our recent API changes which introduced a group array on each item.