### PR TITLE
Return blank array promotion groups if they have no promotions within it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-promos",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "library",
     "description": "Parse promotion arrays from the Wayne State University API",
     "keywords": ["array","parse"],

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -21,6 +21,11 @@ class ParsePromos implements ParserInterface
     {
         $promotions = array();
 
+        // Initialize Promotion Groups
+        foreach((array)$group_reference as $key => $value){
+            $promotions[$value] = array();
+        }
+
         // Re-organize by group id
         if (is_array($promos['promotions'])) {
             // Loop through each promo item

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -33,6 +33,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         $this->groups = array(
             1 => 'one',
             2 => 'two',
+            3 => 'three',
         );
 
         // Stub promotions
@@ -458,5 +459,16 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         foreach ($should_only_be_ints as $key) {
             $this->assertInternalType('int', $key);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function should_be_blank_if_no_promotions_available()
+    {
+        $parsed = $this->parser->parse($this->promos, $this->groups);
+
+        // Make sure a blank array is returned for the 3 group
+        $this->assertEmpty($parsed['three']);
     }
 }


### PR DESCRIPTION
Return a blank array regardless if the promotion group has promotions within it.

version bump to 1.0.1