### PR TITLE
Account for malformed  array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-promos",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "library",
     "description": "Parse promotion arrays from the Wayne State University API",
     "keywords": ["array","parse"],

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -27,7 +27,7 @@ class ParsePromos implements ParserInterface
         }
 
         // Re-organize by group id
-        if (is_array($promos['promotions'])) {
+        if (array_key_exists('promotions', $promos) && is_array($promos['promotions'])) {
             // Loop through each promo item
             foreach ($promos['promotions'] as $item) {
                 // Organize them by their reference

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -150,6 +150,20 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function accountForMalformedArray()
+    {
+        $promos = [];
+
+        // Pass in non-ideal $promos array
+        $parsed = $this->parser->parse($promos, $this->groups);
+
+        // Verify the array has been reorganized without a warning
+        $this->assertArrayHasKey('one', $parsed);
+    }
+
+    /**
+     * @test
+     */
     public function changeKeysToGroupName()
     {
         // Basic parse with no config

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -152,7 +152,7 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
      */
     public function accountForMalformedArray()
     {
-        $promos = [];
+        $promos = array();
 
         // Pass in non-ideal $promos array
         $parsed = $this->parser->parse($promos, $this->groups);


### PR DESCRIPTION
If a non-ideal response comes back from the promotions API this error occurs:

```
1) ParsePromosTest::accountForMalformedArray
Undefined index: promotions
```

This puts more safety in place to account for this and still return an array that is in the parsed format.