### PR TITLE
Allow any variable type to be passed into the parse method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
-
-matrix:
-  include:
-    - php: 5.3
-      dist: precise  
+  - hhvm 
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  include:
+    - php: 5.3
+      dist: precise  
+
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-promos",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "type": "library",
     "description": "Parse promotion arrays from the Wayne State University API",
     "keywords": ["array","parse"],

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/waynestate/parse-promos"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -12,12 +12,12 @@ class ParsePromos implements ParserInterface
     /**
      * Parse the promotions array
      *
-     * @param array $promos
+     * @param mixed $promos
      * @param array $group_reference
      * @param array $config
      * @return array
      */
-    public function parse(array &$promos, array $group_reference = array(), array $config = array())
+    public function parse($promos, array $group_reference = array(), array $config = array())
     {
         $promotions = array();
 

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -7,10 +7,10 @@
 interface ParserInterface
 {
     /**
-     * @param array $promos
+     * @param mixed $promos
      * @param array $group_reference
      * @param array $config
      * @return array
      */
-    public function parse(array &$promos, array $group_reference, array $config);
+    public function parse($promos, array $group_reference, array $config);
 }

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -471,4 +471,17 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
         // Make sure a blank array is returned for the 3 group
         $this->assertEmpty($parsed['three']);
     }
+
+    /**
+     * @test
+     */
+    public function parsing_null_promos_should_return_blank_groups()
+    {
+        $parsed = $this->parser->parse(null, $this->groups);
+
+        // Make sure all groups are blank
+        foreach($parsed as $group) {
+            $this->assertEmpty($group);
+        }
+    }
 }


### PR DESCRIPTION
This is for an effort to make our `waynestate/base-site` repository gracefully load a page if the API is down. Our API connector currently returns `$promos = null` if there are problems from the API. `$promos = null` is then passed to `parsePromos->parse($promos)` which causes a 500 error.

This new code allows for any type to be passed in, which results in the same return as if this was passed in when no promotions were found:

```
$promos['promotions'] = [];

$this->parsePromos->parse($promos)
```