### PR TITLE
hotfix/1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/parse-promos",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "type": "library",
     "description": "Parse promotion arrays from the Wayne State University API",
     "keywords": ["array","parse"],

--- a/src/ParsePromos.php
+++ b/src/ParsePromos.php
@@ -110,7 +110,9 @@ class ParsePromos implements ParserInterface
 
                 // Picks just the first one
                 case 'first':
-                    $array = current($array);
+                    if(count($array) > 0) {
+                        $array = current($array);
+                    }
                     break;
 
                 // Only return the 'per page' associated with a specific page_id

--- a/tests/ParsePromosTest.php
+++ b/tests/ParsePromosTest.php
@@ -489,13 +489,19 @@ class ParsePromosTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function parsing_null_promos_should_return_blank_groups()
+    public function parsing_null_promos_with_configs_should_return_blank_groups()
     {
-        $parsed = $this->parser->parse(null, $this->groups);
+        $config = [
+            'one' => 'first',
+            'two' => 'randomize',
+            'three' => 'limit:2|page_id:2|order:start_date_desc',
+        ];
+
+        $parsed = $this->parser->parse(null, $this->groups, $config);
 
         // Make sure all groups are blank
         foreach($parsed as $group) {
-            $this->assertEmpty($group);
+            $this->assertCount(0, $group);
         }
-    }
+    } 
 }


### PR DESCRIPTION
Fixing a bug when passing the config value of first that it would return false instead of a blank array. Everything else does a blank array so this should be consistent.

I'm doing a minor bump because some older sites might be checking `!== false`.